### PR TITLE
Implement PowerUp and PowerDown events 

### DIFF
--- a/EscapeRoom/Assets/Scripts/BatterySystem/IndependentPowerSystem.cs
+++ b/EscapeRoom/Assets/Scripts/BatterySystem/IndependentPowerSystem.cs
@@ -1,17 +1,23 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Events;
 
 public class IndependentPowerSystem : MonoBehaviour
 {
+    public UnityEvent PowerDown;
+    public UnityEvent PowerUp;
+
     public BatteryMountPoint BatteryPoint;
     private int Draw;
+    private int PreviousPower;    
 
 
     // Start is called before the first frame update
     void Start()
     {
         GameController.Instance.AddIndependentPowerSystem(this);
+        PreviousPower = BatteryPoint.GetCurrentBatteryPowerPercentage();
     }
 
     // Update is called once per frame
@@ -22,8 +28,7 @@ public class IndependentPowerSystem : MonoBehaviour
 
     public bool HasPower()
     {
-        BatteryClass battery = BatteryPoint.GetBattery();
-        if (battery != null && battery.GetBatteryPercent() > 0)
+        if (BatteryPoint.GetCurrentBatteryPowerPercentage() > 0)
             return true;
 
         return false;
@@ -31,7 +36,7 @@ public class IndependentPowerSystem : MonoBehaviour
 
     public string GetPercent()
     {
-        return $"{BatteryPoint.GetBattery().GetBatteryPercent()}%";
+        return $"{BatteryPoint.GetCurrentBatteryPowerPercentage()}%";
     }
 
     public void AddDraw(int draw)
@@ -48,6 +53,15 @@ public class IndependentPowerSystem : MonoBehaviour
 
     public void SystemUpdate()
     {
-        BatteryPoint.GetBattery().UseCharge(Draw);
+        int CurrentPower = BatteryPoint.GetCurrentBatteryPowerPercentage();
+
+        if (PreviousPower <= 0 && CurrentPower > 0)
+            PowerUp.Invoke();
+
+        if (PreviousPower > 0 && CurrentPower <= 0)
+            PowerDown.Invoke();
+
+        PreviousPower = CurrentPower;
+        BatteryPoint.UseCharge(Draw);
     }
 }

--- a/EscapeRoom/Assets/Scripts/Drone Scripts/PlayerController.cs
+++ b/EscapeRoom/Assets/Scripts/Drone Scripts/PlayerController.cs
@@ -42,15 +42,14 @@ public class PlayerController : MonoBehaviour {
         }
 
         BatterySystem = GetComponent<IndependentPowerSystem>();
+        BatterySystem.PowerDown.AddListener(DeactivateDrone);
+        BatterySystem.PowerUp.AddListener(ActivateDrone);
         BatterySystem.AddDraw(1);
     }
 
     // Update is called once per frame
     void Update()
     {
-        if (!BatterySystem.HasPower())
-            DeactivateDrone();
-
         if (!InteractiveMode)
             return;
 
@@ -201,6 +200,14 @@ public class PlayerController : MonoBehaviour {
 
         // Shut off video
         BatteryDisplay.PowerDown();
+    }
+
+    private void ActivateDrone()
+    {
+        if (!CanInteract)
+            CanInteract = true;
+
+        BatteryDisplay.PowerUp();
     }
 
     void FixedUpdate()

--- a/EscapeRoom/Assets/Scripts/VR Player Scripts/BatteryMountPoint.cs
+++ b/EscapeRoom/Assets/Scripts/VR Player Scripts/BatteryMountPoint.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -19,9 +20,9 @@ public class BatteryMountPoint : MountPoint
         
     }
 
-    public BatteryClass GetBattery()
+    public int GetCurrentBatteryPowerPercentage()
     {
-        return Battery;
+        return Battery.GetBatteryPercent();
     }
 
     protected override void Instance_OnShowMountPoints(GameObject mountableObject)
@@ -46,6 +47,11 @@ public class BatteryMountPoint : MountPoint
         }
 
         base.Mount(mountable);
+    }
+
+    public void UseCharge(int draw)
+    {
+        Battery.UseCharge(draw);
     }
 
     public override void UnMount()

--- a/EscapeRoom/unityProject.vrmanifest
+++ b/EscapeRoom/unityProject.vrmanifest
@@ -5,7 +5,7 @@
       "app_key": "application.generated.unity.escaperoom.exe",
       "launch_type": "url",
       "url": "steam://launch/",
-      "action_manifest_path": "C:\\Users\\Sean\\Documents\\GitHub\\EscapeRoom\\EscapeRoom\\Assets\\StreamingAssets\\SteamVR\\actions.json",
+      "action_manifest_path": "C:\\Users\\Jon\\Documents\\GitHub\\EscapeRoom\\EscapeRoom\\Assets\\StreamingAssets\\SteamVR\\actions.json",
       "strings": {
         "en_us": {
           "name": "EscapeRoom [Testing]"


### PR DESCRIPTION
The drone player now responds to battery removal and replacement via events instead of constantly checking the battery in the player update script.